### PR TITLE
Fix selection upgrade's from/to gke versions logic

### DIFF
--- a/expand-contract-upgrade/validate.sh
+++ b/expand-contract-upgrade/validate.sh
@@ -154,7 +154,7 @@ validate_elasticsearch() {
     -o jsonpath='{.spec.replicas}')
 
   if ! [[ "${CLIENTS_REQUEST}" == "${CLIENTS_AVAILABLE}" ]]; then
-    echo -n "ERROR: ${CLIENTS_AVAILABLE} master nodes available, but should be "
+    echo -n "ERROR: ${CLIENTS_AVAILABLE} client nodes available, but should be "
     echo "${MASTERS_REQUEST}"
     return 1
   else
@@ -169,7 +169,7 @@ validate_elasticsearch() {
     -o jsonpath='{.spec.replicas}')
 
   if ! [[ "${DATA_REQUEST}" == "${DATA_AVAILABLE}" ]]; then
-    echo -n "ERROR: ${DATA_AVAILABLE} master nodes available, but should be "
+    echo -n "ERROR: ${DATA_AVAILABLE} data nodes available, but should be "
     echo "${DATA_REQUEST}"
     return 1
   else

--- a/test/configure-jenkins-environment.sh
+++ b/test/configure-jenkins-environment.sh
@@ -13,6 +13,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+function test_versions {
+  test -n "${toVersion}" || { echo >&2 'no toVersion found.. Aborting'; exit 1; }
+  test -n "${fromVersion}" || { echo >&2 'no fromVersion found.. Aborting'; exit 1; }
+  test "${toVersionShortName}" != "${fromVersionShortName}" || { echo >&2 'toVersion and fromVersion selected are equal.. Aborting'; exit 1; }
+  to="$(echo $toVersionShortName | tr -d '.')"
+  from="$(echo $fromVersionShortName | tr -d '.')"
+  test "${to}" -gt "${from}" || { echo >&2 'toVersion is older than fromVersion.. Aborting'; exit 1; }
+}
+
 # All of the scripts expect to find ".env" in the root folder
 cp env .env
 # .env is used as a configuration file for the rest of the project.
@@ -28,6 +37,9 @@ toVersion=${to_from%,*}
 fromVersion=${to_from#*,}
 toVersionShortName=$(echo "$toVersion" | cut -f1 -d'-')
 fromVersionShortName=$(echo "$fromVersion" | cut -f1 -d'-')
+
+# make sure versions are relevant
+test_versions
 
 echo ""
 echo "Selected GKE version to migrate from: ${fromVersion}"

--- a/test/configure-jenkins-environment.sh
+++ b/test/configure-jenkins-environment.sh
@@ -19,10 +19,20 @@ cp env .env
 # Need to choose some values for the automated tests in Jenkins
 GCLOUD_REGION=us-west2
 
-toVersion=$(gcloud container get-server-config --zone "${GCLOUD_REGION}" 2>/dev/null | grep -A 1 validMasterVersions | tail -1 | sed 's/- //')
-fromVersion=$(gcloud container get-server-config --zone "${GCLOUD_REGION}" 2>/dev/null | grep -A 3 validMasterVersions | tail -1 | sed 's/- //')
+# get list of availbale master versions on the specified cloud region
+master_versions=$(gcloud container get-server-config --zone "${GCLOUD_REGION}" 2>/dev/null | awk '/validNodeVersions:/ {f=0;next}; f; /validMasterVersions/ {f=1}' | awk '{print $2}')
+# find two gke versions with different k8s versions
+to_from=$(echo $master_versions | awk '{to_long=$1; split($1,a,"-"); to_short=a[1]; for(i=2;i<= NF;i++) { split($i,b,"-"); if(b[1] != $to_short) {print $to_long","$i; break} }}')
+
+toVersion=${to_from%,*}
+fromVersion=${to_from#*,}
 toVersionShortName=$(echo "$toVersion" | cut -f1 -d'-')
 fromVersionShortName=$(echo "$fromVersion" | cut -f1 -d'-')
+
+echo ""
+echo "Selected GKE version to migrate from: ${fromVersion}"
+echo "Selected GKE version to migrate to -: ${toVersion}"
+echo ""
 
 sed -i "s/export K8S_VER=/export K8S_VER=${fromVersionShortName}/g" .env
 sed -i "s/export NEW_K8S_VER=/export NEW_K8S_VER=${toVersionShortName}/g" .env


### PR DESCRIPTION
The current selection process picks up the last two supported master versions
in GKE and test upgrade from one to the other. Sometimes the picked up kubernetes engine
versions have the same kubernetes version. When this happens, only the the kubernetes
engine patch version changes. This will make the upgrade process faulty when we rely on
the kubernetes versions for upgrade. this patch ensure choosing the last two gke versions
where the corresponding kubernetes versions is also different.