### PR TITLE
Fully parallelize Jenkins builds

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -22,11 +22,12 @@ limitations under the License.
 // Reference: https://github.com/jenkinsci/kubernetes-plugin
 
 // set up pod label and GOOGLE_APPLICATION_CREDENTIALS (for Terraform)
-def label = "k8s-infra"
-def containerName = "k8s-node"
-def GOOGLE_APPLICATION_CREDENTIALS    = '/home/jenkins/dev/jenkins-deploy-dev-infra.json'
-
-podTemplate(label: label, yaml: """
+pipeline {
+  agent {
+    kubernetes {
+      label 'k8s-infra'
+      defaultContainer 'k8s-node'
+      yaml """
 apiVersion: v1
 kind: Pod
 metadata:
@@ -34,7 +35,7 @@ metadata:
     jenkins: build-node
 spec:
   containers:
-  - name: ${containerName}
+  - name: k8s-node
     image: gcr.io/pso-helmsman-cicd/jenkins-k8s-node:${env.CONTAINER_VERSION}
     command: ['cat']
     tty: true
@@ -48,16 +49,15 @@ spec:
     secret:
       secretName: jenkins-deploy-dev-infra
 """
- ) {
- node(label) {
-  try {
-    // Options covers all other job properties or wrapper functions that apply to entire Pipeline.
-    properties([disableConcurrentBuilds()])
-    // set env variable GOOGLE_APPLICATION_CREDENTIALS for Terraform
-    env.GOOGLE_APPLICATION_CREDENTIALS=GOOGLE_APPLICATION_CREDENTIALS
-
+    }
+  }
+  environment {
+    GOOGLE_APPLICATION_CREDENTIALS = '/home/jenkins/dev/jenkins-deploy-dev-infra.json'
+  }
+  stages {
     stage('Setup') {
-        container(containerName) {
+      steps {
+        container('k8s-node-expand-contract') {
           // checkout code from scm i.e. commits related to the PR
           checkout scm
 
@@ -66,52 +66,76 @@ spec:
           sh "gcloud config set compute/zone ${env.CLUSTER_ZONE}"
           sh "gcloud config set core/project ${env.PROJECT_ID}"
           sh "gcloud config set compute/region ${env.REGION}"
-         }
+        }
+        container('k8s-node-rolling-upgrade') {
+          // checkout code from scm i.e. commits related to the PR
+          checkout scm
+
+          // Setup gcloud service account access
+          sh "gcloud auth activate-service-account --key-file=${GOOGLE_APPLICATION_CREDENTIALS}"
+          sh "gcloud config set compute/zone ${env.CLUSTER_ZONE}"
+          sh "gcloud config set core/project ${env.PROJECT_ID}"
+          sh "gcloud config set compute/region ${env.REGION}"
+        }
+        container('k8s-node-blue-green') {
+          // checkout code from scm i.e. commits related to the PR
+          checkout scm
+
+          // Setup gcloud service account access
+          sh "gcloud auth activate-service-account --key-file=${GOOGLE_APPLICATION_CREDENTIALS}"
+          sh "gcloud config set compute/zone ${env.CLUSTER_ZONE}"
+          sh "gcloud config set core/project ${env.PROJECT_ID}"
+          sh "gcloud config set compute/region ${env.REGION}"
+        }
+      }
     }
-    stage('configure environment file') {
+    stage('Configure environment') {
+      steps {
         container('k8s-node') {
           sh './test/configure-jenkins-environment.sh'
         }
+      }
     }
-    // lint relies on .env which will be generate from the `configure environment file` step
     stage('Lint') {
-        container(containerName) {
+      steps {
+        container('k8s-node') {
           sh "make lint"
+        }
       }
     }
-    stage('expand-contract-upgrade') {
-        container('k8s-node') {
-             sh 'make expand-contract-upgrade'
+    stage('Run Tests') {
+      parallel {
+        stage('Expand/Contract Upgrade') {
+          steps {
+            sh 'make expand-contract-upgrade'
+          }
+          post {
+            always {
+              sh 'make expand-contract-upgrade-delete'
+            }
+          }
         }
-    }
-    stage('in-place-rolling-upgrade') {
-        container('k8s-node') {
-          sh 'make in-place-rolling-upgrade'
+        stage('In-Place Rolling Upgrade') {
+          steps {
+            sh 'make in-place-rolling-upgrade'
+          }
+          post {
+            always {
+              sh 'make in-place-rolling-upgrade-delete'
+            }
+          }
         }
-    }
-    stage('blue-green-upgrade') {
-        container('k8s-node') {
+        stage('Blue/Green Upgrade') {
+          steps {
             sh 'make blue-green-upgrade'
+          }
+          post {
+            always {
+              sh 'make blue-green-upgrade-delete'
+            }
+          }
         }
-    }
-
-  }
-   catch (err) {
-      // if any exception occurs, mark the build as failed
-      // and display a detailed message on the Jenkins console output
-      currentBuild.result = 'FAILURE'
-      echo "FAILURE caught echo ${err}"
-      throw err
-   }
-   finally {
-     stage('Teardown') {
-      container(containerName) {
-        sh 'make expand-contract-upgrade-delete'
-        sh 'make in-place-rolling-upgrade-delete'
-        sh 'make blue-green-upgrade-delete'
-        sh 'gcloud auth revoke'
       }
-     }
-   }
+    }
   }
 }

--- a/blue-green-upgrade/cluster_ops.sh
+++ b/blue-green-upgrade/cluster_ops.sh
@@ -72,10 +72,11 @@ load_data() {
 # Installs the hello appF
 install_app() {
   echo "Installing Elasticsearch Cluster"
-  kubectl -n default apply -f "${REPO_HOME}/manifests/es-discovery-svc.yaml"
-  kubectl -n default apply -f "${REPO_HOME}/manifests/es-svc.yaml"
-  kubectl -n default apply -f "${REPO_HOME}/manifests/es-master-pdb.yaml"
-  kubectl -n default apply -f "${REPO_HOME}/manifests/es-master.yaml"
+  hostname
+  kubectl -n default create -f "${REPO_HOME}/manifests/es-discovery-svc.yaml"
+  kubectl -n default create -f "${REPO_HOME}/manifests/es-svc.yaml"
+  kubectl -n default create -f "${REPO_HOME}/manifests/es-master-pdb.yaml"
+  kubectl -n default create -f "${REPO_HOME}/manifests/es-master.yaml"
   kubectl -n default rollout status -f "${REPO_HOME}/manifests/es-master.yaml"
 
   kubectl -n default apply -f "${REPO_HOME}/manifests/es-client-pdb.yaml"

--- a/expand-contract-upgrade/cluster_ops.sh
+++ b/expand-contract-upgrade/cluster_ops.sh
@@ -156,10 +156,11 @@ load_data() {
 ## Installs the Elasticsearch cluster
 setup_app() {
   echo "Installing Elasticsearch Cluster"
-  kubectl -n default apply -f "${REPO_HOME}/manifests/es-discovery-svc.yaml"
-  kubectl -n default apply -f "${REPO_HOME}/manifests/es-svc.yaml"
-  kubectl -n default apply -f "${REPO_HOME}/manifests/es-master-pdb.yaml"
-  kubectl -n default apply -f "${REPO_HOME}/manifests/es-master.yaml"
+  hostname
+  kubectl -n default create -f "${REPO_HOME}/manifests/es-discovery-svc.yaml"
+  kubectl -n default create -f "${REPO_HOME}/manifests/es-svc.yaml"
+  kubectl -n default create -f "${REPO_HOME}/manifests/es-master-pdb.yaml"
+  kubectl -n default create -f "${REPO_HOME}/manifests/es-master.yaml"
   kubectl -n default rollout status -f "${REPO_HOME}/manifests/es-master.yaml"
 
   kubectl -n default apply -f "${REPO_HOME}/manifests/es-client-pdb.yaml"

--- a/expand-contract-upgrade/validate.sh
+++ b/expand-contract-upgrade/validate.sh
@@ -179,10 +179,10 @@ validate_elasticsearch() {
   fi
 
   echo "Setting up port-forward to Elasticsearch Client..."
-  kubectl -n default port-forward svc/elasticsearch 9200:9200 1>&2>/dev/null &
+  kubectl -n default port-forward svc/elasticsearch 9201:9200 1>&2>/dev/null &
   sleep 4
   # Check for Shakespeare search index
-  SHAKESPEARE_INDEX=$(curl -o /dev/null -w "%{http_code}" http://localhost:9200/shakespeare 2>/dev/null)
+  SHAKESPEARE_INDEX=$(curl -o /dev/null -w "%{http_code}" http://localhost:9201/shakespeare 2>/dev/null)
   if ! [[ "$SHAKESPEARE_INDEX" == "200" ]]; then
     echo "ERROR: Shakespeare Index is not available."
     return 1

--- a/in-place-rolling-upgrade/main.tf
+++ b/in-place-rolling-upgrade/main.tf
@@ -27,7 +27,7 @@ data "google_container_engine_versions" "my_zone" {
 // This resource creates an HA Regional GKE cluster
 // https://www.terraform.io/docs/providers/google/r/container_cluster.html
 resource "google_container_cluster" "test" {
-  name   = "rolling-upgrade-test"
+  name   = "${var.cluster_name}"
   region = "${var.region}"
 
   // in a regional cluster, this is the number of nodes per zone
@@ -39,6 +39,7 @@ resource "google_container_cluster" "test" {
   // We specify the machine type for the node pool instances.
   node_config {
     machine_type = "${var.machine_type}"
+
     metadata {
       disable-legacy-endpoints = "true"
     }

--- a/in-place-rolling-upgrade/variables.tf
+++ b/in-place-rolling-upgrade/variables.tf
@@ -17,6 +17,10 @@ limitations under the License.
 // variables.tf - this is where all variables are defined.  The user must
 // provide these for any invocation of `terraform plan`, `apply`, or `destroy`.
 
+variable "cluster_name" {
+  description = "Name to give to the cluster"
+}
+
 variable "region" {
   description = "GCP region where Kubernetes Engine cluster would be created"
 }


### PR DESCRIPTION
Jenkins currently is only able to run a single build at a time and spin up clusters in serial.

This PR adds logic to allow multiple builds to be run at a time and clusters to be spun up in parallel, validated, and then spun back down.

It also cleans up some of cluster ops scripts to more closely adhere to Google's bash style guide.