### PR TITLE
Remove invalid version check

### DIFF
--- a/test/configure-jenkins-environment.sh
+++ b/test/configure-jenkins-environment.sh
@@ -22,10 +22,6 @@ function test_versions() {
   }
   to="$(echo "$toVersionShortName" | sed s/-gke//g | tr -d '.')"
   from="$(echo "$fromVersionShortName" | sed s/-gke//g | tr -d '.')"
-  test "${to}" -gt "${from}" || {
-    echo >&2 'toVersion is older than fromVersion.. Aborting'
-    exit 1
-  }
 }
 
 # All of the scripts expect to find ".env" in the root folder


### PR DESCRIPTION
```
++ gcloud container get-server-config --region us-west1 --project pso-helmsman-cicd-infra --flatten validMasterVersions --format 'value(validMasterVersions)'
+ master_versions='1.13.6-gke.0
1.13.5-gke.10
1.12.7-gke.17
1.12.7-gke.10
1.12.6-gke.11
1.11.9-gke.13
1.11.9-gke.8
1.11.8-gke.6'
++ echo '1.13.6-gke.0
1.13.5-gke.10
1.12.7-gke.17
1.12.7-gke.10
1.12.6-gke.11
1.11.9-gke.13
1.11.9-gke.8
1.11.8-gke.6'
++ head -n 1
+ toVersionShortName=1.13.6-gke.0
++ echo '1.13.6-gke.0
1.13.5-gke.10
1.12.7-gke.17
1.12.7-gke.10
1.12.6-gke.11
1.11.9-gke.13
1.11.9-gke.8
1.11.8-gke.6'
++ head -n 2
++ tail -n 1
+ fromVersionShortName=1.13.5-gke.10
+ test_versions
+ test 1.13.6-gke.0 '!=' 1.13.5-gke.10
++ echo 1.13.6-gke.0
++ sed s/-gke//g
++ tr -d .
+ to=11360
++ echo 1.13.5-gke.10
++ tr -d .
++ sed s/-gke//g
+ from=113510
+ test 11360 -gt 113510
+ echo 'toVersion is older than fromVersion.. Aborting'
toVersion is older than fromVersion.. Aborting
+ exit 1
```
When `1.13.5-gke.10` gets shortened in this way, it gets set to `113510`.  When `1.13.6-gke.0` gets shortened, it gets set to `11360`.  The test for the first entry being greater than the second entry in the version list is something I'm not sure actually happens.  Rather than put in complex bash-only semver checking logic, removal of this test is the most expeditious path.  We can re-add this test logic later if that situation ever actually occurs.